### PR TITLE
update site name to be meaningful

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Ansible PROJECTNAME Documentation
+# Ansible project documentation
 
 > Provide a mission statement or a brief summary of the Ansible project and why someone would want to use it. It should be two or three sentences long, for example:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 ---
-site_name: Ansible PROJECTNAME documentation
+site_name: Ansible project template
 site_url: https://ansible.readthedocs.io/PROJECTNAME
 repo_url: https://github.com/ansible/PROJECTNAME
 edit_uri: blob/main/docs/
@@ -11,8 +11,8 @@ theme:
 
 nav:
   - index.md
-  - installing.md
   - getting_started_user.md
+  - installing.md
   - User Guide:
     - user_guide/how_to_xxx.md
   - References:


### PR DESCRIPTION
This PR changes the site title so it's not confusing when you land on readthedocs. It might be unexpected to find "PROJECTNAME" in the main site title. At first it seems like an error or some kind of test site. We should make this more meaningful.